### PR TITLE
Improve cleanup commands

### DIFF
--- a/art.taunoerik.tauno-serial-plotter.yml
+++ b/art.taunoerik.tauno-serial-plotter.yml
@@ -12,6 +12,11 @@ finish-args:
   - --socket=fallback-x11
   - --share=network
   - --device=all
+cleanup-commands:
+  - /app/cleanup-BaseApp.sh
+build-options:
+  env:
+    - BASEAPP_REMOVE_PYWEBENGINE=1
 
 modules:
   - python3-requirements.json


### PR DESCRIPTION
> While it's not required, it's possible to set the environment variable BASEAPP_REMOVE_WEBENGINE to have the
BaseApp-cleanup.sh script remove the PyQtWebEngine bindings and QtWebEngine with its dependencies.

Source: https://github.com/flathub/com.riverbankcomputing.PyQt.BaseApp?tab=readme-ov-file#example-pyqt-application

The installed size was reduced from **413.7 MB** to **335.2 MB.**

**Please don't forget to test before merging. I don't have an Arduino device to test it.**
